### PR TITLE
Fix default JVM Xmx according to the type of container

### DIFF
--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -4,7 +4,7 @@ calculate_java_memory_opts() {
   local opts=${1:-""}
 
   container_size=$(echo $CONTAINER_SIZE)
-  case $container in
+  case $container_size in
   S)
     echo "$opts -Xmx160m -Xss512k -XX:CICompilerCount=2"
     ;;

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -3,18 +3,27 @@
 calculate_java_memory_opts() {
   local opts=${1:-""}
 
-  limit=$(ulimit -u)
-  case $limit in
-  512)   # 2X, private-s: memory.limit_in_bytes=1073741824
+  container=$(echo $CONTAINER_SIZE)
+  case $container in
+  S)
+    echo "$opts -Xmx160m -Xss512k -XX:CICompilerCount=2"
+    ;;
+  L)
     echo "$opts -Xmx671m -XX:CICompilerCount=2"
     ;;
-  16384) # perf-m, private-m: memory.limit_in_bytes=2684354560
-    echo "$opts -Xmx2g"
+  XL)
+    echo "$opts -Xmx1536m"
     ;;
-  32768) # perf-l, private-l: memory.limit_in_bytes=15032385536
+  2XL)
+    echo "$opts -Xmx3g"
+    ;;
+  3XL)
+    echo "$opts -Xmx6g"
+    ;;
+  4XL)
     echo "$opts -Xmx12g"
     ;;
-  *) # Free, Hobby, 1X: memory.limit_in_bytes=536870912
+  *) # M Container and default if buildpack is used elsewhere
     echo "$opts -Xmx300m -Xss512k -XX:CICompilerCount=2"
     ;;
   esac

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -3,7 +3,7 @@
 calculate_java_memory_opts() {
   local opts=${1:-""}
 
-  container=$(echo $CONTAINER_SIZE)
+  container_size=$(echo $CONTAINER_SIZE)
   case $container in
   S)
     echo "$opts -Xmx160m -Xss512k -XX:CICompilerCount=2"


### PR DESCRIPTION
Fix default Xmx according to the type of container type on Scalingo